### PR TITLE
Update DLC import

### DIFF
--- a/dlc_experiment.py
+++ b/dlc_experiment.py
@@ -8,7 +8,7 @@ from stytra.gui.camera_display import CameraViewWidget
 from stytra.stimulation.estimators import Estimator
 
 from deeplabcut.pose_estimation_tensorflow.config import load_config
-from deeplabcut.pose_estimation_tensorflow.nnet.predict import getposeNP, setup_pose_prediction
+from deeplabcut.pose_estimation_tensorflow.core.predict import getposeNP, setup_pose_prediction
 
 from collections import namedtuple
 from itertools import chain


### PR DESCRIPTION
I just tested against version 2.2.0.6, changing the import from `nnet` to `core` fixed `ModuleNotFoundError: No module named 'deeplabcut.pose_estimation_tensorflow.nnet'`.